### PR TITLE
Iceberg - Add Metainfo

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'pharo-repository'
+}

--- a/pharo-repository/.properties
+++ b/pharo-repository/.properties
@@ -1,0 +1,3 @@
+{
+	#format : #filetree
+}


### PR DESCRIPTION
Best practice. For example, simplifies loading because you don't have to specify the code subfolder in the Metacello repo URL